### PR TITLE
Simplify minirent consumption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: build all and examples
         run: |
-          $CC -o ls ./examples/ls.c
+          $CC -I . -o ls ./examples/ls.c
           ./ls
         env:
           CC: gcc
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: build all and examples
         run: |
-          $CC -o ls ./examples/ls.c
+          $CC -I . -o ls ./examples/ls.c
           ./ls
         env:
           CC: clang
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: build all and examples
         run: |
-          $CC -o ls ./examples/ls.c
+          $CC -I . -o ls ./examples/ls.c
           ./ls
         env:
           CC: clang

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A subset of [dirent](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/d
 
 The code that works with minirent must work with the dirent.
 
+Use minirent as a cross-platform replacement of dirent if you only need the subset interface.
+
 ## Usage
 
 [minirent.h](./minirent.h) is an [stb-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt) header-only library. That means that when you just include it it does not include the implementations of the functions. You have to define `MINIRENT_IMPLEMENTATION` macro:
@@ -15,12 +17,8 @@ The code that works with minirent must work with the dirent.
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef _WIN32
-#    define MINIRENT_IMPLEMENTATION
-#    include <minirent.h>
-#else
-#    include <dirent.h>
-#endif // _WIN32
+#define MINIRENT_IMPLEMENTATION
+#include <minirent.h>
 
 int main(void)
 {

--- a/examples/ls.c
+++ b/examples/ls.c
@@ -4,12 +4,8 @@
 #include <string.h>
 #include <errno.h>
 
-#ifdef _WIN32
-#    define MINIRENT_IMPLEMENTATION
-#    include <minirent.h>
-#else
-#    include <dirent.h>
-#endif // _WIN32
+#define MINIRENT_IMPLEMENTATION
+#include <minirent.h>
 
 int main(int argc, char *argv[])
 {

--- a/minirent.h
+++ b/minirent.h
@@ -34,6 +34,10 @@
 #ifndef MINIRENT_H_
 #define MINIRENT_H_
 
+#ifndef _WIN32
+#include <dirent.h>
+#else // _WIN32
+
 #define WIN32_LEAN_AND_MEAN
 #include "windows.h"
 
@@ -47,8 +51,6 @@ typedef struct DIR DIR;
 DIR *opendir(const char *dirpath);
 struct dirent *readdir(DIR *dirp);
 int closedir(DIR *dirp);
-
-#endif  // MINIRENT_H_
 
 #ifdef MINIRENT_IMPLEMENTATION
 
@@ -133,4 +135,6 @@ int closedir(DIR *dirp)
     return 0;
 }
 
-#endif  // MINIRENT_IMPLEMENTATION
+#endif // MINIRENT_IMPLEMENTATION
+#endif // _WIN32
+#endif // MINIRENT_H_


### PR DESCRIPTION
This change simplifies the integration with this library. It refactors
`#if` guards to automatically include `<dirent.h>` on non-WIN32
platforms.

Therefore, usages of this library can be changed from this:

```c
 #ifdef _WIN32
 #  define MINIRENT_IMPLEMENTATION
 #  include "minirent.h"
 #else
 #  include <dirent.h>
 #endif
```

to this:

```c
 #define MINIRENT_IMPLEMENTATION
 #include "minirent.h"
```

No fuss, no wuss. This should be backwards compatible. README and CI
were updated to reflect it.