### PR TITLE
Add required headers to implementation section

### DIFF
--- a/examples/ls.c
+++ b/examples/ls.c
@@ -1,11 +1,11 @@
+#define MINIRENT_IMPLEMENTATION
+#include <minirent.h>
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-
-#define MINIRENT_IMPLEMENTATION
-#include <minirent.h>
 
 int main(int argc, char *argv[])
 {

--- a/minirent.h
+++ b/minirent.h
@@ -57,6 +57,9 @@ int closedir(DIR *dirp);
 #endif // MINIRENT_H_
 
 #ifdef MINIRENT_IMPLEMENTATION
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 struct DIR
 {


### PR DESCRIPTION
I was trying to use minirent in a niche gaming platform (sometimes called Windows) and it failed to build on its own if I had a file containing only these lines:

```c
#define MINIRENT_IMPLEMENTATION
#include <minirent.h>
```

It required some common C library functions like `assert`, `calloc` and `snprintf`. Since they are not required in non-Windows platforms, I presume it is ok to add the required includes to the implementation block.

I also tweaked the example to move the minirent header to the top of the `ls` example, acting both as a "test" for the implementation block compilation, and to show future users that minirent is self-contained.